### PR TITLE
Fix boost close-outs to use market execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ ETH 永续合约（启用 Boost 模式）：
 python runbot.py --exchange backpack --ticker ETH --direction buy --quantity 0.1 --boost
 ```
 
+### Lighter 交易所：
+
+ETH（启用 Boost 模式）：
+
+```bash
+python runbot.py --exchange lighter --ticker ETH --direction buy --quantity 0.1 --boost
+```
+
 ### Aster 交易所：
 
 ETH：
@@ -331,7 +339,7 @@ python runbot.py --exchange grvt --ticker BTC --quantity 0.05 --take-profit 0.02
 - `--grid-step`: 与下一个平仓订单价格的最小距离百分比（默认：-100，表示无限制）
 - `--stop-price`: 当 `direction` 是 'buy' 时，当 price >= stop-price 时停止交易并退出程序；'sell' 逻辑相反（默认：-1，表示不会因为价格原因停止交易），参数的目的是防止订单被挂在”你认为的开多高点或开空低点“。
 - `--pause-price`: 当 `direction` 是 'buy' 时，当 price >= pause-price 时暂停交易，并在价格回到 pause-price 以下时重新开始交易；'sell' 逻辑相反（默认：-1，表示不会因为价格原因停止交易），参数的目的是防止订单被挂在”你认为的开多高点或开空低点“。
-- `--boost`: 启用 Boost 模式进行交易量提升（仅适用于 aster 和 backpack 交易所）
+- `--boost`: 启用 Boost 模式进行交易量提升（仅适用于 aster、backpack 和 lighter 交易所）
   Boost 模式的下单逻辑：下 maker 单开仓，成交后立即用 taker 单关仓，以此循环。磨损为一单 maker，一单 taker 的手续费，以及滑点。
 
 ## 日志记录

--- a/README_EN.md
+++ b/README_EN.md
@@ -213,6 +213,14 @@ ETH Perpetual (with Boost mode enabled):
 python runbot.py --exchange backpack --ticker ETH --direction buy --quantity 0.1 --boost
 ```
 
+### Lighter Exchange:
+
+ETH (with Boost mode enabled):
+
+```bash
+python runbot.py --exchange lighter --ticker ETH --direction buy --quantity 0.1 --boost
+```
+
 ### Aster Exchange:
 
 ETH:
@@ -307,7 +315,7 @@ python runbot.py --exchange grvt --ticker BTC --quantity 0.05 --take-profit 0.02
 - `--grid-step`: Minimum distance in percentage to the next close order price (default: -100, means no restriction)
 - `--stop-price`: When `direction` is 'buy', stop trading and exit the program when price >= stop-price; 'sell' logic is opposite (default: -1, no price-based termination). The purpose of this parameter is to prevent orders from being placed at "high points for long positions or low points for short positions that you consider".
 - `--pause-price`: When `direction` is 'buy', pause trading when price >= pause-price and resume trading when price falls back below pause-price; 'sell' logic is opposite (default: -1, no price-based pausing). The purpose of this parameter is to prevent orders from being placed at "high points for long positions or low points for short positions that you consider".
-- `--boost`: Enable Boost mode for volume boosting on Aster and Backpack exchanges (only available for 'aster' and 'backpack')
+- `--boost`: Enable Boost mode for volume boosting on Aster, Backpack and Lighter exchanges (only available for 'aster', 'backpack' and 'lighter')
   Boost trading logic: Place maker orders to open positions, immediately close with taker orders after fill, repeat this cycle. Wear consists of one maker order, one taker order fees, and slippage.
 
 ## Logging

--- a/exchanges/lighter.py
+++ b/exchanges/lighter.py
@@ -302,6 +302,82 @@ class LighterClient(BaseExchangeClient):
         order_result = await self._submit_order_with_retry(order_params)
         return order_result
 
+    async def place_market_order(self, contract_id: str, quantity: Decimal, direction: str) -> OrderResult:
+        """Place a market order with Lighter using official SDK."""
+        # Ensure client is initialized
+        if self.lighter_client is None:
+            await self._initialize_lighter_client()
+
+        # Reset current order tracking
+        self.current_order = None
+        self.current_order_client_id = None
+
+        # Determine order side and corresponding price reference
+        best_bid, best_ask = await self.fetch_bbo_prices(contract_id)
+        if direction.lower() == 'buy':
+            is_ask = False
+            execution_price = best_ask
+        elif direction.lower() == 'sell':
+            is_ask = True
+            execution_price = best_bid
+        else:
+            raise Exception(f"Invalid direction: {direction}")
+
+        # Generate unique client order index
+        client_order_index = int(time.time() * 1000) % 1000000
+        self.current_order_client_id = client_order_index
+
+        order_params = {
+            'market_index': self.config.contract_id,
+            'client_order_index': client_order_index,
+            'base_amount': int(quantity * self.base_amount_multiplier),
+            'price': int(execution_price * self.price_multiplier),
+            'is_ask': is_ask,
+            'order_type': self.lighter_client.ORDER_TYPE_MARKET,
+            'time_in_force': self.lighter_client.ORDER_TIME_IN_FORCE_IMMEDIATE_OR_CANCEL,
+            'reduce_only': True,
+            'trigger_price': 0,
+        }
+
+        order_result = await self._submit_order_with_retry(order_params)
+        if not order_result.success:
+            return order_result
+
+        # Wait for websocket update to provide final order status
+        start_time = time.time()
+        order_status = 'OPEN'
+        filled_size = Decimal('0')
+        executed_price = Decimal(execution_price)
+
+        while time.time() - start_time < 10 and order_status != 'FILLED':
+            await asyncio.sleep(0.1)
+            if self.current_order is not None:
+                order_status = self.current_order.status
+                filled_size = self.current_order.filled_size
+                executed_price = self.current_order.price
+
+        if order_status != 'FILLED':
+            self.logger.log(f"Market order failed with status: {order_status}", "ERROR")
+            return OrderResult(
+                success=False,
+                order_id=order_result.order_id,
+                side=direction.lower(),
+                size=quantity,
+                price=Decimal(execution_price),
+                status=order_status,
+                error_message=f"Market order not filled within timeout: {order_status}"
+            )
+
+        return OrderResult(
+            success=True,
+            order_id=self.current_order.order_id,
+            side=direction.lower(),
+            size=filled_size if filled_size > 0 else quantity,
+            price=executed_price,
+            status=order_status,
+            filled_size=filled_size
+        )
+
     async def place_open_order(self, contract_id: str, quantity: Decimal, direction: str) -> OrderResult:
         """Place an open order with Lighter using official SDK."""
 

--- a/runbot.py
+++ b/runbot.py
@@ -90,9 +90,9 @@ async def main():
     # Setup logging first
     setup_logging("WARNING")
 
-    # Validate boost-mode can only be used with aster and backpack exchange
-    if args.boost and args.exchange.lower() != 'aster' and args.exchange.lower() != 'backpack':
-        print(f"Error: --boost can only be used when --exchange is 'aster' or 'backpack'. "
+    # Validate boost-mode can only be used with aster, backpack and lighter exchange
+    if (args.boost and args.exchange.lower() not in ['aster', 'backpack', 'lighter']):
+        print(f"Error: --boost can only be used when --exchange is 'aster', 'backpack' or 'lighter'. "
               f"Current exchange: {args.exchange}")
         sys.exit(1)
 

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -325,10 +325,9 @@ class TradingBot:
             if self.order_filled_amount > 0:
                 close_side = self.config.close_order_side
                 if self.config.boost_mode:
-                    close_order_result = await self.exchange_client.place_close_order(
+                    close_order_result = await self.exchange_client.place_market_order(
                         self.config.contract_id,
                         self.order_filled_amount,
-                        filled_price,
                         close_side
                     )
                 else:


### PR DESCRIPTION
## Summary
- execute boosted close-outs with market orders to match aster/backpack behavior when partially filled positions are cancelled

## Testing
- python -m compileall runbot.py exchanges/lighter.py trading_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68e502459374832787735320d71fcb8a